### PR TITLE
refactor: delegate workflows to actionsforge reusables

### DIFF
--- a/.github/workflows/_auto-assign-issue.yml
+++ b/.github/workflows/_auto-assign-issue.yml
@@ -1,10 +1,10 @@
 name: auto-assign-issue
 on:
   issues:
-    types: 
+    types:
       - opened
 permissions:
   issues: write
 jobs:
   auto-assign:
-    uses: ./.github/workflows/auto-assign-issue.yml
+    uses: actionsforge/actions/.github/workflows/auto-assign-issue.yml@main

--- a/.github/workflows/_commitmsg-conform.yml
+++ b/.github/workflows/_commitmsg-conform.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: read
 jobs:
   commitmsg-conform:
-    uses: ./.github/workflows/commitmsg-conform.yml
+    uses: actionsforge/actions/.github/workflows/commitmsg-conform.yml@main

--- a/.github/workflows/_markdown-lint.yml
+++ b/.github/workflows/_markdown-lint.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: read
 jobs:
   markdown-lint:
-    uses: ./.github/workflows/commitmsg-conform.yml
+    uses: actionsforge/actions/.github/workflows/markdown-lint.yml@main

--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -35,16 +35,13 @@ on:
 
 jobs:
   auto-assign:
-    runs-on: ubuntu-latest
     permissions:
       issues: write
-    steps:
-      - name: 'Auto-assign issue'
-        uses: pozil/auto-assign-issue@v2
-        with:
-          assignees: ${{ inputs.assignees }}
-          numOfAssignee: ${{ inputs.numOfAssignee }}
-          abortIfPreviousAssignees: ${{ inputs.abortIfPreviousAssignees }}
-          removePreviousAssignees: ${{ inputs.removePreviousAssignees }}
-          allowNoAssignees: ${{ inputs.allowNoAssignees }}
-          allowSelfAssign: ${{ inputs.allowSelfAssign }}
+    uses: actionsforge/actions/.github/workflows/auto-assign-issue.yml@main
+    with:
+      assignees: ${{ inputs.assignees }}
+      numOfAssignee: ${{ inputs.numOfAssignee }}
+      abortIfPreviousAssignees: ${{ inputs.abortIfPreviousAssignees }}
+      removePreviousAssignees: ${{ inputs.removePreviousAssignees }}
+      allowNoAssignees: ${{ inputs.allowNoAssignees }}
+      allowSelfAssign: ${{ inputs.allowSelfAssign }}

--- a/.github/workflows/commitmsg-conform.yml
+++ b/.github/workflows/commitmsg-conform.yml
@@ -2,122 +2,12 @@ name: commitmsg-conform
 
 on:
   workflow_call:
-    inputs:
-      config:
-        type: string
-        default: |
-          policies:
-            - type: commit
-              spec:
-                dco: false
-                gpg:
-                  required: false
-                  gitHubOrganization: tfelab
-                spellcheck:
-                  locale: US
-                maximumOfOneCommit: false
-                header:
-                  length: 89
-                  imperative: true
-                  case: lower
-                  invalidLastCharacters: .
-                body:
-                  required: true
-                conventional:
-                  types:
-                    - chore
-                    - ci
-                    - docs
-                    - feat
-                    - fix
-                    - refactor
-                    - release
-                    - revert
-                    - style
-                    - test
-                  scopes: [".*"]
 
 jobs:
-  conform:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.head_ref }}
-      - id: determine-existing-config
-        run: |
-          if [ -f .conform.yaml ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          fi
-      - name: write config
-        if: ${{ steps.determine-existing-config.outputs.exists != 'true' }}
-        run: |
-          cat << EOF > .conform.yaml
-          ${{ inputs.config }}
-          EOF
-      - name: conform
-        env:
-          INPUT_TOKEN: ${{ github.token }}
-        run: |
-          docker run \
-            -e "ACTIONS_CACHE_URL" \
-            -e "ACTIONS_RUNTIME_TOKEN" \
-            -e "ACTIONS_RUNTIME_URL" \
-            -e "GITHUB_ACTION" \
-            -e "GITHUB_ACTION_REF" \
-            -e "GITHUB_ACTION_REPOSITORY" \
-            -e "GITHUB_ACTOR" \
-            -e "GITHUB_ACTOR_ID" \
-            -e "GITHUB_API_URL" \
-            -e "GITHUB_BASE_REF" \
-            -e "GITHUB_ENV" \
-            -e "GITHUB_EVENT_NAME" \
-            -e "GITHUB_EVENT_PATH" \
-            -e "GITHUB_GRAPHQL_URL" \
-            -e "GITHUB_HEAD_REF" \
-            -e "GITHUB_JOB" \
-            -e "GITHUB_OUTPUT" \
-            -e "GITHUB_PATH" \
-            -e "GITHUB_REF" \
-            -e "GITHUB_REF_NAME" \
-            -e "GITHUB_REF_PROTECTED" \
-            -e "GITHUB_REF_TYPE" \
-            -e "GITHUB_REPOSITORY" \
-            -e "GITHUB_REPOSITORY_ID" \
-            -e "GITHUB_REPOSITORY_OWNER" \
-            -e "GITHUB_REPOSITORY_OWNER_ID" \
-            -e "GITHUB_RETENTION_DAYS" \
-            -e "GITHUB_RUN_ATTEMPT" \
-            -e "GITHUB_RUN_ID" \
-            -e "GITHUB_RUN_NUMBER" \
-            -e "GITHUB_SERVER_URL" \
-            -e "GITHUB_SHA" \
-            -e "GITHUB_STATE" \
-            -e "GITHUB_STEP_SUMMARY" \
-            -e "GITHUB_TRIGGERING_ACTOR" \
-            -e "GITHUB_WORKFLOW" \
-            -e "GITHUB_WORKFLOW_REF" \
-            -e "GITHUB_WORKFLOW_SHA" \
-            -e "GITHUB_WORKSPACE" \
-            -e "HOME" \
-            -e "INPUT_ARGS" \
-            -e "RUNNER_ARCH" \
-            -e "RUNNER_ENVIRONMENT" \
-            -e "RUNNER_NAME" \
-            -e "RUNNER_OS" \
-            -e "RUNNER_TEMP" \
-            -e "RUNNER_TOOL_CACHE" \
-            -e "RUNNER_WORKSPACE" \
-            -e CI=true \
-            -e GITHUB_ACTIONS=true \
-            -e GITHUB_EVENT_PATH=/github/workflow/event.json \
-            -e INPUT_TOKEN="$INPUT_TOKEN" \
-            -v "$PWD":"/github/workspace" \
-            -v "/home/runner/work/_temp/_github_home":"/github/home" \
-            -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" \
-            -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" \
-            --workdir /github/workspace \
-            ghcr.io/siderolabs/conform:v0.1.0-alpha.30-1-ga6572d2 \
-            enforce --commit-ref="refs/remotes/origin/main" --reporter=github
+  commitmsg-conform:
+    permissions:
+      statuses: write
+      checks: write
+      contents: read
+      pull-requests: read
+    uses: actionsforge/actions/.github/workflows/commitmsg-conform.yml@main

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,51 +2,12 @@ name: markdown-lint
 
 on:
   workflow_call:
-    inputs:
-      config:
-        type: string
-        required: false
-        default: |
-          {
-            "comment": "Default rules",
-            "default": true,
-            "whitespace": false,
-            "line_length": false,
-            "ul-start-left": false,
-            "ul-indent": false,
-            "no-inline-html": false,
-            "no-bare-urls": false,
-            "fenced-code-language": false,
-            "first-line-h1": false,
-            "no-duplicate-header": false,
-            "no-emphasis-as-header": false,
-            "single-h1": false
-          }
-        description: |
-          a markdownlint compatible JSON object string
-      ignore:
-        type: string
-        required: false
-        default: node_modules
-        description: |
-          a space separated list of directories and files to ignore
 
 jobs:
   markdown-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v4
-
-      - id: lint
-        env:
-          CONFIG: ${{ inputs.config }}
-        run: |
-          IGNORE=""
-          for ITEM in ${{ inputs.ignore }}; do
-            IGNORE="$IGNORE --ignore $ITEM"
-          done
-          CONFIG_FILE="$(mktemp)"
-          cat <<< "$CONFIG" > "$CONFIG_FILE"
-          npm install -g markdownlint-cli@0.41.0
-          markdownlint '**/*.md' $IGNORE -c "$CONFIG_FILE"
+    permissions:
+      statuses: write
+      checks: write
+      contents: read
+      pull-requests: read
+    uses: actionsforge/actions/.github/workflows/markdown-lint.yml@main


### PR DESCRIPTION
## Summary
- Point `_markdown-lint`, `_commitmsg-conform`, and `_auto-assign-issue` at `actionsforge/actions` reusables
- Keep thin `workflow_call` re-exports for the same three workflows
- Removes floating `actions/checkout@v4` and `pozil/auto-assign-issue@v2`
- Fixes `_markdown-lint.yml` which incorrectly called `commitmsg-conform.yml`

## Test plan
- [ ] PR checks run via actionsforge reusables
- [ ] Close stale Dependabot checkout bump PR